### PR TITLE
run checks in parallel

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,13 +116,14 @@ const actionCount = async function(options = {}) {
   const checks = [];
   const start = new Date();
   let hadABreach = false;  // the new code is worse than the old code for this quest
-  for (const name in quests) {
+
+  await Promise.all(Object.keys(quests).map(async name => {
     const quest = quests[name];
     const questStart = new Date();
     const result = await countQuest(quest);
     hadABreach = hadABreach || failedBaseline(quest, result);
     logQuestResult(name, quest, result, Date.now() - questStart.getTime());
-  }
+  }));
 
   if (hadABreach && options.check) {
     console.error(`${RED_X} ${chalk.red.bold("Check failed.")}`);


### PR DESCRIPTION
Not sure if it is important to run them in order or not, but if it isn't we can run the child processes in parallel rather than waiting for each one to complete. Currently in API the `eslint` check for arrow functions takes 4 seconds, so if we add anything else that takes on the order of seconds it'll start to stack up quickly unless we run them in parallel.