### PR TITLE
provide serialize fn to avoid spacing inconsistencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,7 +230,8 @@ const ensureConfig = function() {
   if (!config) {
     config = new Conf({
       configName: "diffjam",
-      cwd: "."
+      cwd: ".",
+      serialize: (value) => JSON.stringify(value, null, 2),
     });
     config.set("quests", {});
   }


### PR DESCRIPTION
this is intended to fix an issue where a developer with a JSON formatter setup in their editor changes diffjam.json manually (for instance, to increase a quest's baseline value).