### PR TITLE
List all breach matches

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -73,8 +73,8 @@ if (cluster.isPrimary || cluster.isMaster) {
           return await (await createRunner())!.count(); // run the policy counter
         case "bump":
           return await (await createRunner())!.bump();
-        case "policy":
-          return await (await createRunner())!.checkPolicy(); // count + fail if warranted
+        case "breaches":
+          return await (await createRunner())!.checkBreachesForPolicy(); // 
         default:
           console.error(`unknown command: ${action}`);
           console.error(cli.help);

--- a/index.ts
+++ b/index.ts
@@ -73,6 +73,8 @@ if (cluster.isPrimary || cluster.isMaster) {
           return await (await createRunner())!.count(); // run the policy counter
         case "bump":
           return await (await createRunner())!.bump();
+        case "policy":
+          return await (await createRunner())!.checkPolicy(); // count + fail if warranted
         default:
           console.error(`unknown command: ${action}`);
           console.error(cli.help);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diffjam",
-  "version": "3.1.4",
+  "version": "3.2.4",
   "description": "cli for diffjam.com",
   "scripts": {
     "build": "make clean && tsc",

--- a/src/Runner.ts
+++ b/src/Runner.ts
@@ -9,7 +9,7 @@ import { Config } from "./Config";
 import { CurrentWorkingDirectory } from "./CurrentWorkingDirectory";
 import { Flags } from "./cli";
 import { Policy } from "./Policy";
-import { GREEN_CHECK, logCheckFailedError, logResults } from "./log";
+import { GREEN_CHECK, logAllResultDetails, logCheckFailedError, logResults } from "./log";
 import { clientVersion } from "./clientVersion";
 import { commentResults, postMetrics, ResultMap } from "./count";
 import { ResultsMap } from './match';
@@ -288,6 +288,13 @@ export class Runner {
 
   modifyPolicy() {
     return actionPolicyModify(this);
+  }
+
+  async checkPolicy() {
+    const ui = require("./ui");
+    const policy = await ui.select("Select a policy to check: ", this.config.policyMap);
+    const result = await this.runSinglePolicy(policy.name);
+    logAllResultDetails(result);
   }
 
   private processFile(filePath: string) {

--- a/src/Runner.ts
+++ b/src/Runner.ts
@@ -290,9 +290,9 @@ export class Runner {
     return actionPolicyModify(this);
   }
 
-  async checkPolicy() {
+  async checkBreachesForPolicy() {
     const ui = require("./ui");
-    const policy = await ui.select("Select a policy to check: ", this.config.policyMap);
+    const policy = await ui.select("Select a policy to check for breaches: ", this.config.policyMap);
     const result = await this.runSinglePolicy(policy.name);
     logAllResultDetails(result);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ export const cli = meow(
       $ diffjam count
       $ diffjam modify
       $ diffjam remove
+      $ diffjam policy
 `,
   {
     flags: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ export const cli = meow(
       $ diffjam count
       $ diffjam modify
       $ diffjam remove
-      $ diffjam policy
+      $ diffjam breaches
 `,
   {
     flags: {

--- a/src/log.ts
+++ b/src/log.ts
@@ -46,6 +46,27 @@ const logBreachError = (breach: Result) => {
   }
 };
 
+export const logAllResultDetails = (result: Result) => {
+  console.log(
+    `${chalk.yellow.bold(result.policy.name)} (found ${result.matches.length}, expecting ${result.policy.baseline
+    } or fewer)`
+  );
+
+  const matches = result.matches;
+
+  const longestFilePath = maxBy(matches, example => example.breachPath.length)!.breachPath.length
+
+  const matchLog = matches
+    .map(b => `${chalk.magenta(b.breachPath)}${" ".repeat(longestFilePath - b.breachPath.length)} ${b.startWholeLineFormatted}`)
+    .join("\n")
+
+  console.log(matchLog);
+
+  if (result.policy.description) {
+    console.error(chalk.yellow(result.policy.description));
+  }
+};
+
 export const logResults = (resultsMap: ResultsMap, _filesChecked: string[]) => {
   const all = Object.values(resultsMap);
   const [successes, breaches] = partition(all, ({ policy, matches }) => policy.isCountAcceptable(matches));


### PR DESCRIPTION
Adds a command `breaches` to list out all breaches for a selected policy. Functionality is similar to how `modify -> see current state` works today but with the output formatting of `diffjam check`:

<img width="1045" alt="Screenshot 2023-07-27 at 3 17 15 PM" src="https://github.com/diffjam/diffjam/assets/5808938/53ebbbfb-e0ff-4ad4-b724-1e853cc7aadf">